### PR TITLE
Add portfolio selection modules

### DIFF
--- a/src/portfolioConstruction/__init__.py
+++ b/src/portfolioConstruction/__init__.py
@@ -1,0 +1,7 @@
+"""Portfolio construction utilities."""
+
+from .barra_equity_selector import select_equities
+from .fixed_income_selection import select_fixed_income
+from .alternatives_selection import select_alternatives
+
+__all__ = ["select_equities", "select_fixed_income", "select_alternatives"]

--- a/src/portfolioConstruction/alternatives_selection.py
+++ b/src/portfolioConstruction/alternatives_selection.py
@@ -1,0 +1,36 @@
+"""Selection utilities for alternative assets.
+
+This module provides a basic momentum‑based strategy which can be used
+for alternative asset classes such as commodities or currencies.  The
+interface returns a list of assets with the strongest positive momentum.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+
+def select_alternatives(
+    prices: pd.DataFrame, window: int = 60, top_n: int = 5
+) -> List[str]:
+    """Select alternative assets using a simple momentum signal.
+
+    Parameters
+    ----------
+    prices : pandas.DataFrame
+        Price series with assets in columns and time in rows.
+    window : int, optional
+        Look‑back window for momentum calculation, by default 60.
+    top_n : int, optional
+        Number of assets to return, by default 5.
+
+    Returns
+    -------
+    list of str
+        The ``top_n`` assets with the highest momentum.
+    """
+
+    momentum = prices.pct_change(window).iloc[-1]
+    return list(momentum.nlargest(top_n).index)

--- a/src/portfolioConstruction/barra_equity_selector.py
+++ b/src/portfolioConstruction/barra_equity_selector.py
@@ -1,0 +1,101 @@
+"""Utilities for equity selection using a simplified BARRA factor model.
+
+The functions in this module implement a light‑weight workflow for
+factor exposure estimation, idiosyncratic risk calculation and a basic
+risk‑adjusted selection routine.  The goal is to provide a minimal
+interface that returns a list of chosen assets given historical returns
+and factor data.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import numpy as np
+import pandas as pd
+
+
+def compute_factor_exposures(
+    returns: pd.DataFrame, factor_returns: pd.DataFrame
+) -> pd.DataFrame:
+    """Estimate factor exposures via ordinary least squares.
+
+    Parameters
+    ----------
+    returns : pandas.DataFrame
+        Asset returns with assets in columns and time in rows.
+    factor_returns : pandas.DataFrame
+        Factor returns aligned on the same index as ``returns``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        Estimated factor exposures (betas) for each asset.
+    """
+
+    exposures = {}
+    X = factor_returns.values
+    for asset in returns:
+        y = returns[asset].values
+        beta, *_ = np.linalg.lstsq(X, y, rcond=None)
+        exposures[asset] = beta
+    return pd.DataFrame(exposures, index=factor_returns.columns).T
+
+
+def compute_idiosyncratic_risk(
+    returns: pd.DataFrame, factor_returns: pd.DataFrame, exposures: pd.DataFrame
+) -> pd.Series:
+    """Compute idiosyncratic risk (residual variance) for each asset."""
+
+    common = factor_returns.dot(exposures.T)
+    residuals = returns - common
+    return residuals.var()
+
+
+def optimize_selection(
+    expected_returns: pd.Series,
+    exposures: pd.DataFrame,
+    factor_cov: pd.DataFrame,
+    idiosyncratic_risk: pd.Series,
+    risk_aversion: float = 1.0,
+    top_n: int = 10,
+) -> List[str]:
+    """Select assets by a simple mean‑variance score.
+
+    Assets are ranked by ``expected_return - risk_aversion * variance``
+    where variance combines both factor and idiosyncratic components.
+    """
+
+    scores = {}
+    for asset in expected_returns.index:
+        beta = exposures.loc[asset].values
+        systematic = beta @ factor_cov.values @ beta
+        total_var = systematic + idiosyncratic_risk[asset]
+        scores[asset] = expected_returns[asset] - risk_aversion * total_var
+    return [a for a, _ in sorted(scores.items(), key=lambda x: x[1], reverse=True)[:top_n]]
+
+
+def select_equities(
+    returns: pd.DataFrame,
+    factor_returns: pd.DataFrame,
+    expected_returns: pd.Series,
+    factor_cov: pd.DataFrame,
+    risk_aversion: float = 1.0,
+    top_n: int = 10,
+) -> List[str]:
+    """Full pipeline returning a list of selected equities.
+
+    This function ties together exposure estimation, idiosyncratic risk
+    calculation and the simple optimization routine.
+    """
+
+    exposures = compute_factor_exposures(returns, factor_returns)
+    idio = compute_idiosyncratic_risk(returns, factor_returns, exposures)
+    return optimize_selection(
+        expected_returns=expected_returns,
+        exposures=exposures,
+        factor_cov=factor_cov,
+        idiosyncratic_risk=idio,
+        risk_aversion=risk_aversion,
+        top_n=top_n,
+    )

--- a/src/portfolioConstruction/fixed_income_selection.py
+++ b/src/portfolioConstruction/fixed_income_selection.py
@@ -1,0 +1,43 @@
+"""Fixed income selection utilities.
+
+This module implements a minimal example of a fixed income selection
+model using yield‑curve changes and credit spread information.  The
+interface returns a list of selected bonds based on a simple scoring
+metric that combines carry and spread momentum.
+"""
+
+from __future__ import annotations
+
+from typing import List
+
+import pandas as pd
+
+
+def select_fixed_income(
+    yields: pd.DataFrame,
+    credit_spreads: pd.DataFrame,
+    top_n: int = 10,
+) -> List[str]:
+    """Select bonds using yield‑curve and credit spread signals.
+
+    Parameters
+    ----------
+    yields : pandas.DataFrame
+        Bond yields with assets in columns and time in rows.
+    credit_spreads : pandas.DataFrame
+        Credit spread data aligned with ``yields``.
+    top_n : int, optional
+        Number of assets to return, by default 10.
+
+    Returns
+    -------
+    list of str
+        The ``top_n`` bonds with the most attractive combined score.
+    """
+
+    # Carry: prefer higher current yield.
+    carry = yields.iloc[-1]
+    # Spread momentum: improving (decreasing) spreads are positive.
+    spread_mom = -credit_spreads.diff().iloc[-1]
+    score = carry + spread_mom
+    return list(score.nlargest(top_n).index)


### PR DESCRIPTION
## Summary
- add simplified BARRA equity selector with factor exposures, idiosyncratic risk and optimization
- introduce fixed income selector using yield carry and credit spread momentum
- provide alternative asset selector based on momentum

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68946ac886208330a91a4016da6f5fb1